### PR TITLE
Fix encryption issues with TLS12

### DIFF
--- a/tlspuffin/src/fuzzer/mutations.rs
+++ b/tlspuffin/src/fuzzer/mutations.rs
@@ -744,15 +744,6 @@ mod tests {
             let mut trace = seed_client_attacker12.build_trace();
             mutator.mutate(&mut state, &mut trace, 0).unwrap();
 
-            let is_last_not_encrypt = if let Some(last) = trace.steps.iter().last() {
-                match &last.action {
-                    Action::Input(input) => Some(input.recipe.name() != fn_encrypt12.name()),
-                    Action::Output(_) => None,
-                }
-            } else {
-                None
-            };
-
             let is_first_not_ch = if let Some(first) = trace.steps.get(0) {
                 match &first.action {
                     Action::Input(input) => Some(input.recipe.name() != fn_client_hello.name()),
@@ -762,9 +753,20 @@ mod tests {
                 None
             };
 
+            let is_next_not_fn_client_key_exchange = if let Some(next) = trace.steps.get(1) {
+                match &next.action {
+                    Action::Input(input) => {
+                        Some(input.recipe.name() != fn_client_key_exchange.name())
+                    }
+                    Action::Output(_) => None,
+                }
+            } else {
+                None
+            };
+
             if let Some(first) = is_first_not_ch {
-                if let Some(last) = is_last_not_encrypt {
-                    if first && last {
+                if let Some(second) = is_next_not_fn_client_key_exchange {
+                    if first && second {
                         break;
                     }
                 }

--- a/tlspuffin/src/wolfssl/callbacks.rs
+++ b/tlspuffin/src/wolfssl/callbacks.rs
@@ -86,7 +86,7 @@ pub struct UserData {
 pub unsafe extern "C" fn ctx_msg_callback<F>(
     write_p: c_int,
     _version: c_int,
-    _content_type: c_int,
+    content_type: c_int,
     buf: *const c_void,
     _len: c_ulong,
     ssl: *mut wolf::WOLFSSL,
@@ -106,14 +106,19 @@ pub unsafe extern "C" fn ctx_msg_callback<F>(
 
     let ssl = SslRef::from_ptr_mut(ssl);
 
-    let typ = HandshakeType::from(*(buf as *mut u8));
+    let typ = if content_type == 22 {
+        HandshakeType::from(*(buf as *mut u8))
+    } else {
+        HandshakeType::Unknown(0)
+    };
+
     (*callback)(ssl, typ, write_p == 1);
 }
 
 pub unsafe extern "C" fn ssl_msg_callback<F>(
     write_p: c_int,
     _version: c_int,
-    _content_type: c_int,
+    content_type: c_int,
     buf: *const c_void,
     _len: c_ulong,
     ssl: *mut wolf::WOLFSSL,
@@ -131,6 +136,11 @@ pub unsafe extern "C" fn ssl_msg_callback<F>(
         callback.deref() as *const F
     };
 
-    let typ = HandshakeType::from(*(buf as *mut u8));
+    let typ = if content_type == 22 {
+        HandshakeType::from(*(buf as *mut u8))
+    } else {
+        HandshakeType::Unknown(0)
+    };
+
     (*callback)(ssl, typ, write_p == 1);
 }


### PR DESCRIPTION
By "casting" an OpaqueMessage to a message, messages can be come corruped.

e.g. encrypted alerts becomes an unencrypted alert with a random warning level.
